### PR TITLE
Tune light colour categorization for Kelvin values

### DIFF
--- a/js/parse_scripts.js
+++ b/js/parse_scripts.js
@@ -794,13 +794,13 @@ function getMarkerIcon(L,lightSource,lightMethod,lightColour,lightFlash,lightDir
 			let KelvinLength = lightColour.indexOf("K");
 			let lightColourK = Number(lightColour.substr(0,KelvinLength));
 			if (!lightColourK.isNaN) {
-				if (lightColourK < 2000) {
+				if (lightColourK <= 2000) {
 					colourURL = "_gas";
-				} else if (lightColourK < 2600) {
+				} else if (lightColourK <= 2600) {
 					colourURL = "_orange";
-				} else if (lightColourK < 3000) {
+				} else if (lightColourK <= 3000) {
 					colourURL = "_fluorescent";
-				} else if (lightColourK < 4000) {
+				} else if (lightColourK <= 4000) {
 					colourURL = "_led";
 				} else if (lightColourK > 5600) {
 					colourURL = "_mercury";


### PR DESCRIPTION
Hi @sb12, what a nice and aesthetic project!

I've used it to explore different street lights and noticed that some lights may not be best presented on the map - these with the Kelvin values for the `light:colour` tags. You added support for these values at issue #10, but I believe that my minor changes will enhance this tag representation.

For example, `3000 K` values are shown as white lights, although they are considered more orange (thus the fluorescent branch will suit those better).

Here is an image for reference :)

<img width="1920" height="1032" alt="temperatures" src="https://www.any-lamp.com/media/wysiwyg/colour_temperature_1.webp" />
